### PR TITLE
dockerfile: Define the containarized env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# centos:stream8
+FROM quay.io/centos/centos:stream8
+
+COPY requirements.txt /
+
+RUN \
+    dnf -y install \
+      python38 \
+      sqlite \
+    && \
+    dnf clean all \
+    && \
+    python3 -m pip install -r requirements.txt
+
+WORKDIR /workspace/django-testing-tutorial
+
+EXPOSE 8000/tcp
+
+CMD ["python3", "/workspace/django-testing-tutorial/manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# -django-testing-tutorial-os-07
+# django-testing-tutorial
+A learning tutorial about testing Django
+
+## Build, Deploy and Run
+The project has been originally targeted to be deployed through a
+container.
+However, it is not limited by it and should be available on any env.
+
+Dedicated instruction on how to build and use the project exist for:
+- [podman](README.podman.md) [1]
+
+
+[1] The instructions should also work with `docker`, but it has not
+been formally tested.
+
+## LICENSE
+The project uses a [MIT License](LICENSE).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,33 @@
+# Base: centos:stream8
+
+# Django
+asgiref==3.5.0
+backports.zoneinfo==0.2.1
+Django==4.0.3
+sqlparse==0.4.2
+
+# pytest
+attrs==21.4.0
+iniconfig==1.1.1
+packaging==21.3
+pluggy==1.0.0
+py==1.11.0
+pyparsing==3.0.7
+pytest==7.1.0
+pytest-django==4.5.2
+tomli==2.0.1
+
+# linters
+## flake8
+flake8==4.0.1
+mccabe==0.6.1
+pycodestyle==2.8.0
+pyflakes==2.4.0
+
+## black (formatter)
+black==22.1.0
+click==8.0.4
+mypy-extensions==0.4.3
+pathspec==0.9.0
+platformdirs==2.5.1
+typing-extensions==4.1.1


### PR DESCRIPTION
Provide a containarized environment to test and run the django
project.

Containarizing the development environment allows all developers
to use the same exact components, having no dependency on the
underlay platform.

One can create an image from the Dockerfile by running:

`podman build -f dockerfile/Dockerfile -t beyond .` from the
project root.